### PR TITLE
CLoud-to-device message timestamp issue fixed

### DIFF
--- a/src/Types/Encoder.cs
+++ b/src/Types/Encoder.cs
@@ -61,9 +61,9 @@ namespace Amqp.Types
 
 #if NETMF
         // NETMF DateTime ticks origin is 1601/1/1
-        const long epochTicks = 116444736000000000; // 1970-1-1 00:00:00 UTC
+        const long epochTicks = 621355968000000000; // 1601-1-1 00:00:00 UTC
 #else
-        const long epochTicks = 621355968000000000; // 1970-1-1 00:00:00 UTC
+        const long epochTicks = 116444736000000000; // 1970-1-1 00:00:00 UTC
 #endif
         internal const long TicksPerMillisecond = 10000;
         static Serializer[] serializers;


### PR DESCRIPTION
the following definitions within the #IF block were entered the wrong way round and have been corrected;

#if NETMF
        // NETMF DateTime ticks origin is 1601/1/1
        const long epochTicks = 621355968000000000; // 1601-1-1 00:00:00 UTC
#else
        const long epochTicks = 116444736000000000; // 1970-1-1 00:00:00 UTC
#endif